### PR TITLE
Edited the VideoViewSet's 'stream_video' action to return a FileResponse  of the retrieved video's entire content

### DIFF
--- a/main/views.py
+++ b/main/views.py
@@ -132,9 +132,14 @@ class VideoViewSet(GenericViewSet):
                          f"{self.lookup_field} {kwargs.get('pk')!r} does not exist."
             }, status=status.HTTP_404_NOT_FOUND)
 
-        chunk_generator = (chunk.chunk_file.read() for chunk in video.chunks.all())
+        def chunk_generator(video_file=video.video_file, chunk_size=1024*1024):
+            while True:
+                chunk = video_file.read(chunk_size)
+                if not chunk:
+                    break
+                yield chunk
 
-        response = FileResponse(chunk_generator, content_type='video/mp4')
+        response = FileResponse(chunk_generator(), content_type='video/mp4')
         response['Content-Disposition'] = f'inline; filename="{video.title}.mp4"'
         return response
 


### PR DESCRIPTION
This Pull request addresses issue #11.

A known flaw and/or edge case to this is that the _video_file_ field in use may not be updated, as the RabbitMQ consumer may still be busy merging the existing video file with some latest chunk, hence, the streamed content would not be complete. 

But then, the chunks are intended to be appended while the user is recording, so except if they attempt to stream the video within a short period after recording, this works.